### PR TITLE
Fix index out of bounds crash

### DIFF
--- a/src/main/java/ToDoList.java
+++ b/src/main/java/ToDoList.java
@@ -1,4 +1,5 @@
 import command.Command;
+import command.CommandException;
 import command.EmptyCommand;
 import parser.ParseException;
 import parser.Parser;
@@ -42,7 +43,7 @@ public class ToDoList {
         return new EmptyCommand();
     }
 
-    public void runCommand(Command<TaskList> command) {
+    public void runCommand(Command<TaskList> command) throws CommandException {
         command.run(taskList);
         storage.save(taskList, saveDirectory);
     }
@@ -59,7 +60,11 @@ public class ToDoList {
         String input = scanner.next();
         while (!input.equals("exit")) {
             Command<TaskList> command = toDoList.readInput(input);
-            toDoList.runCommand(command);
+            try {
+                toDoList.runCommand(command);
+            } catch (CommandException ce) {
+                ce.printStackTrace();
+            }
             toDoList.displayOutput();
             input = scanner.next();
         }

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -4,6 +4,6 @@ import task.TaskList;
 
 public interface Command<T> {
 
-    public void run(T t);
+    public void run(T t) throws CommandException;
 
 }

--- a/src/main/java/command/CommandException.java
+++ b/src/main/java/command/CommandException.java
@@ -1,0 +1,8 @@
+package command;
+
+public class CommandException extends Exception {
+
+    public CommandException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/command/CompleteTaskCommand.java
+++ b/src/main/java/command/CompleteTaskCommand.java
@@ -12,8 +12,12 @@ public class CompleteTaskCommand implements Command<TaskList> {
         this.index = index;
     }
 
-    public void run(TaskList list) {
-        list.completeTask(day, index);
+    public void run(TaskList list) throws CommandException {
+        try {
+            list.completeTask(day, index);
+        } catch (IndexOutOfBoundsException ioobe) {
+            throw new CommandException(ioobe.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/command/DeleteTaskCommand.java
+++ b/src/main/java/command/DeleteTaskCommand.java
@@ -12,8 +12,12 @@ public class DeleteTaskCommand implements Command<TaskList> {
         this.index = index;
     }
 
-    public void run(TaskList taskList) {
-        taskList.deleteTask(day, index);
+    public void run(TaskList taskList) throws CommandException {
+        try {
+            taskList.deleteTask(day, index);
+        } catch (IndexOutOfBoundsException ioobe) {
+            throw new CommandException(ioobe.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/command/EditTaskCommand.java
+++ b/src/main/java/command/EditTaskCommand.java
@@ -17,10 +17,9 @@ public class EditTaskCommand implements Command<TaskList> {
 
     @Override
     public void run(TaskList taskList) throws CommandException {
-        Task oldTask = taskList.getTask(blockName, index);
-        boolean isDone = oldTask.isDone();
-
         try {
+            Task oldTask = taskList.getTask(blockName, index);
+            boolean isDone = oldTask.isDone();
             taskList.addTask(blockName, newDescription, isDone, index);
             taskList.deleteTask(blockName, index + 1);
         } catch (IndexOutOfBoundsException ioobe) {

--- a/src/main/java/command/EditTaskCommand.java
+++ b/src/main/java/command/EditTaskCommand.java
@@ -16,12 +16,16 @@ public class EditTaskCommand implements Command<TaskList> {
     }
 
     @Override
-    public void run(TaskList taskList) {
+    public void run(TaskList taskList) throws CommandException {
         Task oldTask = taskList.getTask(blockName, index);
         boolean isDone = oldTask.isDone();
 
-        taskList.addTask(blockName, newDescription, isDone, index);
-        taskList.deleteTask(blockName, index + 1);
+        try {
+            taskList.addTask(blockName, newDescription, isDone, index);
+            taskList.deleteTask(blockName, index + 1);
+        } catch (IndexOutOfBoundsException ioobe) {
+            throw new CommandException(ioobe.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/command/UndoTaskCommand.java
+++ b/src/main/java/command/UndoTaskCommand.java
@@ -12,8 +12,12 @@ public class UndoTaskCommand implements Command<TaskList> {
         this.index = index;
     }
 
-    public void run(TaskList taskList) {
-        taskList.uncompleteTask(day, index);
+    public void run(TaskList taskList) throws CommandException {
+        try {
+            taskList.uncompleteTask(day, index);
+        } catch (IndexOutOfBoundsException ioobe) {
+            throw new CommandException(ioobe.getMessage());
+        }
     }
 
     @Override

--- a/src/test/java/command/CompleteTaskCommandTest.java
+++ b/src/test/java/command/CompleteTaskCommandTest.java
@@ -11,7 +11,7 @@ import static template.TaskListTemplate.STRING_DESCRIPTION_THREE;
 public class CompleteTaskCommandTest extends CommandTestTemplate {
 
     @Test
-    public void run_validCompleteCommand_success() {
+    public void run_validCompleteCommand_success() throws CommandException {
         CompleteTaskCommand command = new CompleteTaskCommand("monday", 1);
         Task expectedTask = new Task(STRING_DESCRIPTION_ONE);
         expectedTask.markDone();
@@ -21,7 +21,7 @@ public class CompleteTaskCommandTest extends CommandTestTemplate {
     }
 
     @Test
-    public void run_indexAlreadyComplete_noChange() {
+    public void run_indexAlreadyComplete_noChange() throws CommandException {
         CompleteTaskCommand command = new CompleteTaskCommand("tuesday", 1);
         Task expectedTask = new Task(STRING_DESCRIPTION_THREE);
         expectedTask.markDone();
@@ -38,11 +38,11 @@ public class CompleteTaskCommandTest extends CommandTestTemplate {
         CompleteTaskCommand command4 = new CompleteTaskCommand("tuesday", 0);
         CompleteTaskCommand command5 = new CompleteTaskCommand("wednesday", 1);
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command1.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command2.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command3.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command4.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command5.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command1.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command2.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command3.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command4.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command5.run(modelTaskList));
     }
 
 }

--- a/src/test/java/command/DeleteTaskCommandTest.java
+++ b/src/test/java/command/DeleteTaskCommandTest.java
@@ -7,7 +7,7 @@ import template.CommandTestTemplate;
 public class DeleteTaskCommandTest extends CommandTestTemplate {
 
     @Test
-    public void run_validDeleteCommand_success() {
+    public void run_validDeleteCommand_success() throws CommandException {
         DeleteTaskCommand command1 = new DeleteTaskCommand("monday", 2);
         DeleteTaskCommand command2 = new DeleteTaskCommand("tuesday", 1);
         DeleteTaskCommand command3 = new DeleteTaskCommand("monday", 1);
@@ -39,11 +39,11 @@ public class DeleteTaskCommandTest extends CommandTestTemplate {
         DeleteTaskCommand command4 = new DeleteTaskCommand("tuesday", 0);
         DeleteTaskCommand command5 = new DeleteTaskCommand("wednesday", 1);
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command1.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command2.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command3.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command4.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command5.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command1.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command2.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command3.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command4.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command5.run(modelTaskList));
     }
 
 }

--- a/src/test/java/command/EditTaskCommandTest.java
+++ b/src/test/java/command/EditTaskCommandTest.java
@@ -14,7 +14,7 @@ public class EditTaskCommandTest extends CommandTestTemplate {
     private final String EDIT_DESCRIPTION_TWO = "edit to this two";
 
     @Test
-    public void run_validEditCommand_success() {
+    public void run_validEditCommand_success() throws CommandException {
         EditTaskCommand command1 = new EditTaskCommand("monday", 2, EDIT_DESCRIPTION_ONE);
         EditTaskCommand command2 = new EditTaskCommand("tuesday", 1, EDIT_DESCRIPTION_TWO);
         Task expectedTask1 = new Task(EDIT_DESCRIPTION_ONE);
@@ -36,11 +36,11 @@ public class EditTaskCommandTest extends CommandTestTemplate {
         EditTaskCommand command4 = new EditTaskCommand("tuesday", 0, EDIT_DESCRIPTION_ONE);
         EditTaskCommand command5 = new EditTaskCommand("wednesday", 1, EDIT_DESCRIPTION_TWO);
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command1.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command2.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command3.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command4.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command5.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command1.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command2.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command3.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command4.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command5.run(modelTaskList));
     }
 
 }

--- a/src/test/java/command/UndoTaskCommandTest.java
+++ b/src/test/java/command/UndoTaskCommandTest.java
@@ -11,7 +11,7 @@ import static template.TaskListTemplate.STRING_DESCRIPTION_THREE;
 public class UndoTaskCommandTest extends CommandTestTemplate {
 
     @Test
-    public void run_validUndoCommand_success() {
+    public void run_validUndoCommand_success() throws CommandException {
         UndoTaskCommand command = new UndoTaskCommand("tuesday", 1);
         Task expectedTask = new Task(STRING_DESCRIPTION_THREE);
         expectedTask.markUndone();
@@ -21,7 +21,7 @@ public class UndoTaskCommandTest extends CommandTestTemplate {
     }
 
     @Test
-    public void run_indexAlreadyUndone_noChange() {
+    public void run_indexAlreadyUndone_noChange() throws CommandException {
         UndoTaskCommand command = new UndoTaskCommand("monday", 1);
         Task expectedTask = new Task(STRING_DESCRIPTION_ONE);
 
@@ -37,11 +37,11 @@ public class UndoTaskCommandTest extends CommandTestTemplate {
         UndoTaskCommand command4 = new UndoTaskCommand("tuesday", 0);
         UndoTaskCommand command5 = new UndoTaskCommand("wednesday", 1);
 
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command1.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command2.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command3.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command4.run(modelTaskList));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> command5.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command1.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command2.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command3.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command4.run(modelTaskList));
+        Assertions.assertThrows(CommandException.class, () -> command5.run(modelTaskList));
     }
 
 }


### PR DESCRIPTION
`IndexOutOfBoundsException` was causing program to crash. 

Update exception handling to handle this.