### PR TITLE
[#18] Bug: Opening and closing without editing corrupts the save file

### DIFF
--- a/src/main/java/core/ToDoList.java
+++ b/src/main/java/core/ToDoList.java
@@ -16,6 +16,7 @@ public class ToDoList {
 
     private static final String SAVEFILE_NAME = "todolist-save";
     private static final Path DEFAULT_PATH = Paths.get(SAVEFILE_NAME);
+    private static final String MESSAGE_NOT_SAVED = "Not saved properly.";
 
     private final Storage storage;
     private final IOInterface ioInterface;
@@ -36,7 +37,10 @@ public class ToDoList {
 
     public void runCommand(Command<TaskList> command) throws CommandException {
         command.run(taskList);
-        storage.save(taskList, saveDirectory);
+        boolean isSaved = storage.save(taskList, saveDirectory);
+        if (!isSaved) {
+            throw new CommandException(MESSAGE_NOT_SAVED);
+        }
     }
 
     public void run() {

--- a/src/main/java/gui/MainApplication.java
+++ b/src/main/java/gui/MainApplication.java
@@ -13,13 +13,14 @@ import java.util.concurrent.CompletableFuture;
 public class MainApplication extends Application {
 
     private MainWindow mainWindow;
+    private CompletableFuture<Void> toDoListRunner;
 
      @Override
      public void start(Stage stage) {
          mainWindow = new MainWindow();
          IOInterface ioInterface = new GuiIO(mainWindow);
          ToDoList toDoList = new ToDoList(ioInterface);
-         CompletableFuture.runAsync(toDoList::run);
+         toDoListRunner = CompletableFuture.runAsync(toDoList::run);
          Scene scene = new Scene(mainWindow.getRoot());
          stage.setScene(scene);
          stage.setTitle("To-Do-List");
@@ -31,6 +32,7 @@ public class MainApplication extends Application {
      @Override
      public void stop() {
          mainWindow.runUserCommand(new ExitCommand());
+         toDoListRunner.join();
      }
 
 }

--- a/src/main/java/gui/MainWindow.java
+++ b/src/main/java/gui/MainWindow.java
@@ -45,6 +45,4 @@ public class MainWindow extends GuiComponent<AnchorPane> {
             scrollPane.requestFocus();
         });
     }
-
-
 }

--- a/src/main/java/storage/JsonStorageImpl.java
+++ b/src/main/java/storage/JsonStorageImpl.java
@@ -37,7 +37,6 @@ public class JsonStorageImpl implements Storage {
         Optional<TaskList> optionalTaskList;
         try {
             JsonTaskList jsonTaskList = objectMapper.readValue(Paths.get(path.toString()).toFile(), JsonTaskList.class);
-            objectMapper.writeValue(Paths.get(path.toString()).toFile(), jsonTaskList);
             optionalTaskList = Optional.of(jsonTaskList.toJavaType());
         } catch (IOException ioe) {
             ioe.printStackTrace();

--- a/src/main/java/storage/JsonStorageImpl.java
+++ b/src/main/java/storage/JsonStorageImpl.java
@@ -37,6 +37,7 @@ public class JsonStorageImpl implements Storage {
         Optional<TaskList> optionalTaskList;
         try {
             JsonTaskList jsonTaskList = objectMapper.readValue(Paths.get(path.toString()).toFile(), JsonTaskList.class);
+            objectMapper.writeValue(Paths.get(path.toString()).toFile(), jsonTaskList);
             optionalTaskList = Optional.of(jsonTaskList.toJavaType());
         } catch (IOException ioe) {
             ioe.printStackTrace();


### PR DESCRIPTION
Fixes #18 

Issue likely arose from program terminating before the `EndCommand` could be executed to completion which corrupted the save file. In forcing the completion of the `CompletableFuture` which results in a final save of the current `ToDoList`, it fixes the issue.

Test cases have not been added as it requires the launch and closure of the main application, relating to #17.