### PR TITLE
[#40] Allow multiple commands to be run before saving

### DIFF
--- a/src/main/java/core/ToDoList.java
+++ b/src/main/java/core/ToDoList.java
@@ -29,6 +29,8 @@ public class ToDoList {
     private static final String ERROR_GETTING_INPUT = "Error encountered when retrieving user input.";
     private static final String ERROR_COMMAND_RUN = "Unable to run command: %s";
     private static final String ERROR_SAVING = "Unable to save to %s.";
+    private static final String ERROR_UNEXPECTED_EXCEPTION =
+            "Unexpected error encountered. Command was not run properly.";
 
     private final Storage storage;
     private final IoInterface ioInterface;
@@ -83,6 +85,9 @@ public class ToDoList {
         } catch (CommandException ce) {
             logger.log(Level.WARNING, String.format(ERROR_COMMAND_RUN, command), ce);
             ioInterface.displayErrorMessage(ce.getMessage());
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, ERROR_UNEXPECTED_EXCEPTION, e);
+            ioInterface.displayErrorMessage(ERROR_UNEXPECTED_EXCEPTION);
         }
     }
 

--- a/src/main/java/core/ToDoList.java
+++ b/src/main/java/core/ToDoList.java
@@ -5,13 +5,16 @@ import command.CommandException;
 import command.ExitCommand;
 import io.InputException;
 import io.IoInterface;
+
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import logging.LogsManager;
 import storage.JsonStorageImpl;
-import storage.SaveException;
 import storage.Storage;
 import task.TaskList;
 
@@ -21,8 +24,6 @@ public class ToDoList {
     private static final String SAVEFILE_DIRECTORY = "to-do-list";
     private static final String SAVEFILE_NAME = "todolist-save";
     private static final Path DEFAULT_SAVE_PATH = Paths.get(SAVEFILE_DIRECTORY, SAVEFILE_NAME);
-    private static final String LOGFILE_NAME = "todolist-logs";
-    private static final Path DEFAULT_LOG_PATH = Paths.get(SAVEFILE_DIRECTORY, LOGFILE_NAME);
     private static final String MESSAGE_NOT_SAVED = "Not saved properly.";
 
     private static final String ERROR_GETTING_INPUT = "Error encountered when retrieving user input.";
@@ -42,10 +43,20 @@ public class ToDoList {
     public ToDoList(IoInterface ioInterface) {
         storage = new JsonStorageImpl();
         this.ioInterface = ioInterface;
-        saveDirectory = DEFAULT_SAVE_PATH;
-        taskList = storage.load(saveDirectory)
-                .orElse(new TaskList());
         logger = LogsManager.getLogger(this.getClass());
+        saveDirectory = DEFAULT_SAVE_PATH;
+        taskList = loadTaskList(DEFAULT_SAVE_PATH)
+                .orElse(new TaskList());
+    }
+
+    private Optional<TaskList> loadTaskList(Path path) {
+        try {
+            return Optional.of(storage.load(path));
+        } catch (IOException ie) {
+            logger.log(Level.WARNING, MESSAGE_NOT_SAVED, ie);
+            ioInterface.displayErrorMessage(MESSAGE_NOT_SAVED);
+        }
+        return Optional.empty();
     }
 
     /**
@@ -62,11 +73,16 @@ public class ToDoList {
     /**
      * Runs the given {@code command} on its {@code taskList}.
      */
-    public void runCommand(Command<TaskList> command) throws SaveException, CommandException {
-        command.run(taskList);
-        boolean isSaved = storage.save(taskList, saveDirectory);
-        if (!isSaved) {
-            throw new SaveException(MESSAGE_NOT_SAVED);
+    public void runCommand(Command<TaskList> command) {
+        try {
+            command.run(taskList);
+            storage.save(taskList, saveDirectory);
+        } catch (IOException ie) {
+            logger.log(Level.WARNING, ERROR_SAVING, ie);
+            ioInterface.displayErrorMessage(ERROR_SAVING);
+        } catch (CommandException ce) {
+            logger.log(Level.WARNING, String.format(ERROR_COMMAND_RUN, command), ce);
+            ioInterface.displayErrorMessage(ce.getMessage());
         }
     }
 
@@ -76,25 +92,23 @@ public class ToDoList {
      */
     public void run() {
         ioInterface.displayOnStartup(taskList);
-        Command<TaskList> command = null;
-        while (!isExitCommand(command)) {
+        List<Command<TaskList>> commands = null;
+        boolean isExitCommand = false;
+        while (!isExitCommand) {
             try {
-                command = ioInterface.getUserInput();
+                commands = ioInterface.getUserInput();
             } catch (InputException ie) {
                 logger.log(Level.WARNING, ERROR_GETTING_INPUT, ie);
                 ioInterface.displayErrorMessage(ie.getMessage());
                 continue;
             }
 
-            try {
+            for (Command<TaskList> command : commands) {
                 runCommand(command);
                 ioInterface.updateUser(taskList);
-            } catch (CommandException ce) {
-                logger.log(Level.WARNING, String.format(ERROR_COMMAND_RUN, command), ce);
-                ioInterface.displayErrorMessage(ce.getMessage());
-            } catch (SaveException se) {
-                logger.log(Level.SEVERE, String.format(ERROR_SAVING, saveDirectory), se);
-                ioInterface.displayErrorMessage(se.getMessage());
+                if (isExitCommand(command)) {
+                    isExitCommand = true;
+                }
             }
         }
     }

--- a/src/main/java/io/IoInterface.java
+++ b/src/main/java/io/IoInterface.java
@@ -3,12 +3,14 @@ package io;
 import command.Command;
 import task.TaskList;
 
+import java.util.List;
+
 public interface IoInterface {
 
     /**
      * Returns the current user request in the form of a {@code Command<TaskList>}.
      */
-    public Command<TaskList> getUserInput() throws InputException;
+    public List<Command<TaskList>> getUserInput() throws InputException;
 
     /**
      * Updates the user's view with the change in {@code taskList}.

--- a/src/main/java/io/gui/CommandMessenger.java
+++ b/src/main/java/io/gui/CommandMessenger.java
@@ -3,11 +3,18 @@ package io.gui;
 import command.Command;
 import task.TaskList;
 
+import java.util.List;
+
 public interface CommandMessenger {
 
     /**
      *  Updates backend with current {@code userCommand}.
      */
     public void updateUserCommand(Command<TaskList> userCommand);
+
+    /**
+     * Updates backend with given {@code commands} executed sequentially.
+     */
+    public void updateUserCommands(List<Command<TaskList>> userCommands);
 
 }

--- a/src/main/java/io/gui/CommandSync.java
+++ b/src/main/java/io/gui/CommandSync.java
@@ -1,12 +1,21 @@
 package io.gui;
 
 import command.Command;
+
+import java.util.List;
 import java.util.concurrent.Semaphore;
 import task.TaskList;
 
 public class CommandSync implements CommandMessenger {
 
+    private static final String MESSAGE_UNEXPECTED_ISSUE = "Unexpected issue encountered with acquiring user input.";
+
+    private boolean isList = false;
+    private List<Command<TaskList>> userCommands;
+
+    private boolean isSingleCommand = false;
     private Command<TaskList> userCommand;
+
     private final Semaphore semaphore;
 
     public CommandSync() {
@@ -17,17 +26,35 @@ public class CommandSync implements CommandMessenger {
     /**
      * Retrieves the next command from the user.
      */
-    public Command<TaskList> getUserCommand() {
+    public List<Command<TaskList>> getUserCommand() {
         try {
             semaphore.acquire();
         } catch (InterruptedException ie) {
             ie.printStackTrace();
         }
-        return userCommand;
+
+        if (isList) {
+            return userCommands;
+        } else if (isSingleCommand) {
+            return List.of(userCommand);
+        } else {
+            throw new RuntimeException(MESSAGE_UNEXPECTED_ISSUE);
+        }
     }
 
+    @Override
     public void updateUserCommand(Command<TaskList> userCommand) {
         this.userCommand = userCommand;
+        isSingleCommand = true;
+        isList = false;
+        semaphore.release();
+    }
+
+    @Override
+    public void updateUserCommands(List<Command<TaskList>> userCommands) {
+        this.userCommands = userCommands;
+        isList = true;
+        isSingleCommand = false;
         semaphore.release();
     }
 }

--- a/src/main/java/io/gui/GuiIO.java
+++ b/src/main/java/io/gui/GuiIO.java
@@ -6,6 +6,8 @@ import io.InputException;
 import io.IoInterface;
 import task.TaskList;
 
+import java.util.List;
+
 public class GuiIO implements IoInterface {
 
     private final MainWindow mainWindow;
@@ -21,7 +23,7 @@ public class GuiIO implements IoInterface {
     }
 
     @Override
-    public Command<TaskList> getUserInput() throws InputException {
+    public List<Command<TaskList>> getUserInput() throws InputException {
         return commandSync.getUserCommand();
     }
 

--- a/src/main/java/storage/JsonStorageImpl.java
+++ b/src/main/java/storage/JsonStorageImpl.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Optional;
 import task.TaskList;
 
 public class JsonStorageImpl implements Storage {

--- a/src/main/java/storage/JsonStorageImpl.java
+++ b/src/main/java/storage/JsonStorageImpl.java
@@ -20,43 +20,24 @@ public class JsonStorageImpl implements Storage {
     }
 
     @Override
-    public boolean save(TaskList list, Path path) {
+    public boolean save(TaskList list, Path path) throws IOException {
         JsonTaskList jsonTaskList = JsonTaskList.convertToJson(list);
 
         boolean doesFileExist = Files.exists(path);
         Path parentDirectory = path.getParent();
         boolean doesParentDirectoryExist = Files.exists(parentDirectory);
         if (!doesFileExist && !doesParentDirectoryExist) {
-            try {
-                Files.createDirectory(parentDirectory);
-            } catch (IOException e) {
-                e.printStackTrace();
-                return false;
-            }
+            Files.createDirectory(parentDirectory);
         }
 
-        boolean isSaved;
-        try {
-            objectMapper.writeValue(Paths.get(path.toString()).toFile(), jsonTaskList);
-            isSaved = true;
-        } catch (IOException ioe) {
-            isSaved = false;
-            ioe.printStackTrace();
-        }
-        return isSaved;
+        objectMapper.writeValue(Paths.get(path.toString()).toFile(), jsonTaskList);
+        return true;
     }
 
     @Override
-    public Optional<TaskList> load(Path path) {
-        Optional<TaskList> optionalTaskList;
-        try {
-            JsonTaskList jsonTaskList = objectMapper.readValue(Paths.get(path.toString()).toFile(), JsonTaskList.class);
-            optionalTaskList = Optional.of(jsonTaskList.toJavaType());
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-            optionalTaskList = Optional.empty();
-        }
-        return optionalTaskList;
+    public TaskList load(Path path) throws IOException {
+        JsonTaskList jsonTaskList = objectMapper.readValue(Paths.get(path.toString()).toFile(), JsonTaskList.class);
+        return jsonTaskList.toJavaType();
     }
 
 }

--- a/src/main/java/storage/Storage.java
+++ b/src/main/java/storage/Storage.java
@@ -1,5 +1,6 @@
 package storage;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import task.TaskList;
@@ -11,12 +12,11 @@ public interface Storage {
      * If {@code path} does not exist, creates a new save file.
      * If {@code path} exists, overwrites current file.
      */
-    public boolean save(TaskList list, Path path);
+    public boolean save(TaskList list, Path path) throws IOException;
 
     /**
      * Loads the task list from the given {@code path}.
-     * If no available save file is found, returns an empty {@code Optional}.
      */
-    public Optional<TaskList> load(Path path);
+    public TaskList load(Path path) throws IOException;
 
 }

--- a/src/test/java/storage/JsonStorageImplTest.java
+++ b/src/test/java/storage/JsonStorageImplTest.java
@@ -1,5 +1,6 @@
 package storage;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -17,22 +18,20 @@ public class JsonStorageImplTest {
     private final Storage storage = new JsonStorageImpl();
 
     @Test
-    public void saveAndLost_normalTaskList_success() {
+    public void saveAndLost_normalTaskList_success() throws IOException {
         TaskList expectedList = TaskListTemplate.buildTaskListTemplate();
         // directory already exists
         storage.save(expectedList, TEST_FILE_PATH_WITH_DIRECTORY);
 
-        Optional<TaskList> optionalTaskList = storage.load(TEST_FILE_PATH_WITH_DIRECTORY);
-        Assertions.assertTrue(optionalTaskList.isPresent());
-        Assertions.assertEquals(expectedList, optionalTaskList.get());
+        TaskList taskList = storage.load(TEST_FILE_PATH_WITH_DIRECTORY);
+        Assertions.assertEquals(expectedList, taskList);
         FileUtil.deleteFile(TEST_FILE_PATH_WITH_DIRECTORY);
 
         //directory does not already exist
         storage.save(expectedList, TEST_FILE_PATH_NO_DIRECTORY);
 
-        optionalTaskList = storage.load(TEST_FILE_PATH_NO_DIRECTORY);
-        Assertions.assertTrue(optionalTaskList.isPresent());
-        Assertions.assertEquals(expectedList, optionalTaskList.get());
+        taskList = storage.load(TEST_FILE_PATH_NO_DIRECTORY);
+        Assertions.assertEquals(expectedList, taskList);
         FileUtil.deleteFile(TEST_FILE_PATH_NO_DIRECTORY);
     }
 }


### PR DESCRIPTION
Resolves #40 

It changes the `getUserInput` method to return a list of commands instead of a single command. This change allows for efficiency in implementing more diverse actions that constitute multiple commands, enabling them to execute in succession without saving until the last command is completed.

The `updateUserCommands` method in `CommandSync` allows gui parts to send a list of commands instead of just a single command.