### PR TITLE
[#45] OOP: Json storage classes implement a common interface contract

### DIFF
--- a/src/main/java/storage/JsonStorer.java
+++ b/src/main/java/storage/JsonStorer.java
@@ -1,0 +1,9 @@
+package storage;
+
+public interface JsonStorer<T> {
+
+    /**
+     * Converts JSON storer into its respective functional java type {@code T}.
+     */
+    public T toJavaType();
+}

--- a/src/main/java/storage/JsonTask.java
+++ b/src/main/java/storage/JsonTask.java
@@ -3,7 +3,7 @@ package storage;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import task.Task;
 
-public class JsonTask {
+public class JsonTask implements JsonStorer<Task> {
 
     private final String description;
     private final boolean isDone;
@@ -14,6 +14,7 @@ public class JsonTask {
         this.isDone = isDone;
     }
 
+    @Override
     public Task toJavaType() {
         return new Task(description, isDone);
     }

--- a/src/main/java/storage/JsonTaskBlock.java
+++ b/src/main/java/storage/JsonTaskBlock.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import task.TaskBlock;
 
-public class JsonTaskBlock {
+public class JsonTaskBlock implements JsonStorer<TaskBlock> {
 
     private final String blockHeader;
     private final List<JsonTask> tasks;

--- a/src/main/java/storage/JsonTaskList.java
+++ b/src/main/java/storage/JsonTaskList.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import task.TaskBlock;
 import task.TaskList;
 
-public class JsonTaskList {
+public class JsonTaskList implements JsonStorer<TaskList> {
 
     private final Map<String, JsonTaskBlock> blocks;
 
@@ -24,9 +24,7 @@ public class JsonTaskList {
         }
     }
 
-    /**
-     * Returns the Java equivalent {@code TaskList} of itself.
-     */
+    @Override
     public TaskList toJavaType() {
         Map<String, TaskBlock> nonJsonBlocks = new LinkedHashMap<>();
         for (String day : BLOCK_NAMES) {


### PR DESCRIPTION
Resolves #45 

Implements the common `JsonStorer` interface which dictates a method to convert it back to its functional java type. 