### PR TITLE
[#50] Block names can take on days-of-week with white spaces

### DIFF
--- a/src/main/java/command/AddBlockCommand.java
+++ b/src/main/java/command/AddBlockCommand.java
@@ -9,7 +9,7 @@ public class AddBlockCommand implements Command<TaskList> {
     private final Optional<Integer> optionalInteger;
 
     public AddBlockCommand(String blockName) {
-        this.blockName = blockName;
+        this.blockName = blockName.strip();
         optionalInteger = Optional.empty();
     }
 

--- a/src/main/java/command/EditBlockCommand.java
+++ b/src/main/java/command/EditBlockCommand.java
@@ -11,7 +11,7 @@ public class EditBlockCommand implements Command<TaskList> {
 
     public EditBlockCommand(int index, String newHeader) {
         this.index = index;
-        this.newHeader = newHeader;
+        this.newHeader = newHeader.strip();
     }
 
     @Override


### PR DESCRIPTION
Fixes #50 

At present, block names can be added and edited to take up names of days of weeks with additional white space. 

This changes the default to strip strings of white space before being parsed as a block name.