### PR TITLE
Fix issue with blank screen

### DIFF
--- a/src/main/java/gui/MainApplication.java
+++ b/src/main/java/gui/MainApplication.java
@@ -28,6 +28,7 @@ public class MainApplication extends Application {
     private static final String WINDOW_SETTING_FILENAME = "window-settings";
     private static final String MESSAGE_NO_SETTINGS_FOUND = "No settings were found. Using default.";
     private static final String MESSAGE_SETTINGS_NOT_SAVED = "Settings were not saved properly.";
+    private static final String UNCAUGHT_EXCEPTION_FOUND = "Uncaught exception found!";
     private static final double DEFAULT_HEIGHT = 400.0;
     private static final double DEFAULT_WIDTH = 400.0;
     private static final double MIN_HEIGHT = 400.0;
@@ -83,9 +84,14 @@ public class MainApplication extends Application {
 
     @Override
     public void stop() {
-        saveWindowSettings();
-        mainWindow.runUserCommand(new ExitCommand());
-        toDoListRunner.join();
+        try {
+            saveWindowSettings();
+            mainWindow.runUserCommand(new ExitCommand());
+            toDoListRunner.join();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, UNCAUGHT_EXCEPTION_FOUND, e);
+            LOGGER.log(Level.SEVERE, UNCAUGHT_EXCEPTION_FOUND, e.getCause());
+        }
     }
 
     /**

--- a/src/main/java/gui/MainWindow.java
+++ b/src/main/java/gui/MainWindow.java
@@ -48,11 +48,11 @@ public class MainWindow extends GuiComponent<AnchorPane> {
             nodeList.add(nodeToAdd);
         }
 
-        wrapperBox.getChildren().add(0, new AddTaskBlockGui(ADD_BLOCK_UPPER_INDEX).getRoot());
-        lowerAddTaskBlock = new AddTaskBlockGui(nodeList.size());
-        wrapperBox.getChildren().add(lowerAddTaskBlock.getRoot());
-
         Platform.runLater(() -> {
+            wrapperBox.getChildren().add(0, new AddTaskBlockGui(ADD_BLOCK_UPPER_INDEX).getRoot());
+            lowerAddTaskBlock = new AddTaskBlockGui(nodeList.size());
+            wrapperBox.getChildren().add(lowerAddTaskBlock.getRoot());
+
             // Replaces current nodes
             taskListGui.getChildren().clear();
             taskListGui.getChildren().addAll(nodeList);


### PR DESCRIPTION
After the recent PR merge, launch produces a blank screen.

Caused by not using `Platform.runLater` for one of the node changes.

Crucially to note that the error message did not show up anywhere except on closure when the `stop()` method is executed. Better logging has been added to the `stop` method.